### PR TITLE
Updated /tasks/readability.js to split on both \n and \r\n line endings

### DIFF
--- a/tasks/readability.js
+++ b/tasks/readability.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
                 } else { return true; }
 			}).map(function (filePath) {
 				var contents = grunt.file.read(filePath),
-					linesArray = contents.trim().split("\n");
+					linesArray = contents.trim().split(/\r?\n/);
 
 				filesScanned += 1;
 


### PR DESCRIPTION
Hi Justin,

Hope you're doing well. I had some issues with lines containing exactly 80 characters on my windows machine, due to the files being created locally with /r/n line endings. This change fixes these cases.

Thanks,
Mike Cebrian